### PR TITLE
only 20 pulled if number included in query

### DIFF
--- a/ecommerceapi/views/product/products.py
+++ b/ecommerceapi/views/product/products.py
@@ -36,8 +36,12 @@ class Products(ViewSet):
     
     def list(self, request):
         ''' handles get requests to server and returns a JSON response'''
-        
-        products = Product.objects.all()
+        home = self.request.query_params.get('number', None)
+        if home is not None:
+            products = Product.objects.all()[:20]
+        else:
+             products = Product.objects.all()
+
         serializer = ProductSerializer(products, many=True, context={"request": request})
         return Response(serializer.data)
     


### PR DESCRIPTION
Fixes #18 

# Fetching Instructions
```shell
git fetch --all
git checkout kk-new-home-list
python manage.py runserver
```
# For the Web app
```shell
git fetch --all
git checkout kk-homelist
npm start
```

# Description
Please include a summary of the change and which issue is fixed.
added the functionality to only pull the most recent 20 products
added a new card to show products on the homepage

# List of changes
- added some sweet cards ♥️
- they show the product and the description and the date created (not formated yet)
- the card may change to have a details button instead of the drop down description.
- once both servers are running just visit the homepage and see that it shows up. only the 3 - current products we have are being listed cause we dont have more than 20.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings