### PR TITLE
Kk start order

### DIFF
--- a/bangazonllc/urls.py
+++ b/bangazonllc/urls.py
@@ -23,6 +23,7 @@ from ecommerceapi.views import *
 router = routers.DefaultRouter(trailing_slash=False)
 # router.register(r'customers', Customers, 'customer')
 router.register(r'products', Products, 'products')
+router.register(r'orders', Orders, 'order')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/bangazonllc/urls.py
+++ b/bangazonllc/urls.py
@@ -25,6 +25,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'products', Products, 'products')
 router.register(r'orders', Orders, 'order')
 router.register(r'payment_types', Payments, 'payment_types')
+router.register(r'order_products', OrderProducts, 'orderproducts')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/ecommerceapi/models/order.py
+++ b/ecommerceapi/models/order.py
@@ -1,5 +1,6 @@
 from django.db import models
 from .customer import Customer
+from django.db.models import F
 from .payment_type import PaymentType
 
 class Order(models.Model):
@@ -16,3 +17,6 @@ class Order(models.Model):
   customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING)
   payment_type = models.ForeignKey(PaymentType, on_delete=models.DO_NOTHING, blank=True, null=True)
   created_at = models.DateTimeField()
+
+  class Meta:
+        ordering = (F('created_at').desc(nulls_last=True),)

--- a/ecommerceapi/views/__init__.py
+++ b/ecommerceapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .register import register_user, login_user
 from .product import Products
+from .order import Orders

--- a/ecommerceapi/views/__init__.py
+++ b/ecommerceapi/views/__init__.py
@@ -2,3 +2,4 @@ from .payment import PaymentSerializer, Payments
 from .register import register_user, login_user
 from .product import Products
 from .order import Orders
+from .order_product import OrderProducts

--- a/ecommerceapi/views/order/__init__.py
+++ b/ecommerceapi/views/order/__init__.py
@@ -1,0 +1,1 @@
+from .orders import Orders

--- a/ecommerceapi/views/order/orders.py
+++ b/ecommerceapi/views/order/orders.py
@@ -1,0 +1,40 @@
+'''
+A django page to handle all order fetch calls
+
+'''
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from ecommerceapi.models import Order, Customer
+
+class OrderSerializer(serializers.HyperlinkedModelSerializer):
+    '''
+        This funciton serializes an array from the db and turns it into JSON :D
+    '''
+    class Meta:
+        model = Order
+        url = serializers.HyperlinkedIdentityField(
+            view_name = 'orders',
+            lookup_field = "id"
+        )
+        fields = ('id', 'payment_type_id', 'created_at')
+    
+
+class Orders(ViewSet):
+    
+    def list(self, request):
+
+        customer = Customer.objects.get(user=request.auth.user)
+        orders = Order.objects.all()
+        orders = orders.filter(customer = customer)
+        paymentType = self.request.query_params.get('payment_type_id', None)
+        if paymentType is not None:
+            orders.filter(payment_type_id = paymentType)
+        serializer = OrderSerializer(orders, many=True, context={'request': request})
+
+        return Response(serializer.data)
+
+
+    

--- a/ecommerceapi/views/order/orders.py
+++ b/ecommerceapi/views/order/orders.py
@@ -3,6 +3,7 @@ A django page to handle all order fetch calls
 
 '''
 from django.http import HttpResponseServerError
+import datetime
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -26,6 +27,11 @@ class Orders(ViewSet):
     
     def list(self, request):
 
+        '''
+        This function returns all of the orders associated with the current user, (based of token). It is important to note that it is ordered
+        by date so the first item returned is the most recent and if that payment type id is null than it is an open cart
+        '''
+
         customer = Customer.objects.get(user=request.auth.user)
         orders = Order.objects.all()
         orders = orders.filter(customer = customer)
@@ -35,6 +41,25 @@ class Orders(ViewSet):
         serializer = OrderSerializer(orders, many=True, context={'request': request})
 
         return Response(serializer.data)
+    
+    def create(self, request):
+        '''
+            Handles creating a new order when a user hits add to cart
+        '''
+        customer = Customer.objects.get(user=request.auth.user)
+        date = datetime.datetime.now()
+        newOrder = Order()
+        newOrder.customer = customer
+        newOrder.created_at = date
+        newOrder.payment_type_id = None
+
+        newOrder.save()
+
+        serialize = OrderSerializer(newOrder, context={'request': request})
+        return Response(serialize.data)
+    
+
+
 
 
     

--- a/ecommerceapi/views/order_product/__init__.py
+++ b/ecommerceapi/views/order_product/__init__.py
@@ -1,0 +1,1 @@
+from .order_products import OrderProducts

--- a/ecommerceapi/views/order_product/order_products.py
+++ b/ecommerceapi/views/order_product/order_products.py
@@ -1,0 +1,51 @@
+'''
+A django page to handle all order fetch calls
+
+'''
+from django.http import HttpResponseServerError
+import datetime
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from ecommerceapi.models import Order, Customer, Product, OrderProduct
+
+class OrderProductSerializer(serializers.HyperlinkedModelSerializer):
+    '''
+        This funciton serializes an array from the db and turns it into JSON :D
+    '''
+    class Meta:
+        model = OrderProduct
+        url = serializers.HyperlinkedIdentityField(
+            view_name = 'order_products',
+            lookup_field = "id"
+        )
+        fields = ('id', 'order_id', 'product_id')
+    
+
+class OrderProducts(ViewSet):
+    
+    def list(self, request):
+
+        '''
+        This function returns all of the order-product relationships and has the option to filter by order number
+        '''
+
+        order_products = OrderProduct.objects.all()
+        order_id = self.request.query_params.get('order_id', None)
+        if order_id is not None:
+            order_products = order_products.filter(order_id = order_id)
+        serializer = OrderProductSerializer(order_products, many=True, context={'request': request})
+
+        return Response(serializer.data)
+    
+    def create(self, request):
+
+        new_order_product = OrderProduct()
+        new_order_product.order_id =  request.data["order_id"]
+        new_order_product.product_id =  request.data["product_id"]
+        new_order_product.save()
+
+        serializer = OrderProductSerializer(new_order_product, context={'request': request})
+        return Response(serializer.data)
+


### PR DESCRIPTION
Fixes #13 section b (adding items to cart)

# Fetching Instructions
```shell
git fetch --all
git checkout kk-start-order
```

# Description
Users can now click add to cart (on the product details page only I will eventually add to home page as a stretch goal). If the user currently has an order open it will add the current product to that order and if it will create a new order and add the product to that order. 

# List of changes
- created Orders view and Order_product views (list and create only)
- update URLS.py 


# Testing:
- must be authenticated in the React app to add product to cart or the app will crash

- Once on my branch you need use Postman to view changes because we do not have a order view end point yet. below are the urls you will use to see the changes
-  `localhost:8000/order_products`
- `localhost:8000/orders`
- to full test go to the details page of a product and click "Add to Cart" if you do no have a current open order it will create a new one and then add that product
- add another product and see that it gets added to the same order 
- in TablePlus change the payment_type_id of that most recent order to 1, 2 or 3 and the see that creates a new order

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings