### PR TITLE
Kk cancel order

### DIFF
--- a/ecommerceapi/tests.py
+++ b/ecommerceapi/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/ecommerceapi/tests/__init__.py
+++ b/ecommerceapi/tests/__init__.py
@@ -1,0 +1,1 @@
+from .testorders import TestOrders

--- a/ecommerceapi/tests/testorders.py
+++ b/ecommerceapi/tests/testorders.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.urls import reverse
+from ecommerceapi.models import Order, Customer
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from unittest import skip
+
+class TestOrders(TestCase):
+
+    def setUp(self):
+        self.username = "TestUser"
+        self.password = "testword1"
+        self.user =  User.objects.create_user(
+            username=self.username, password=self.password)
+        self.token = Token.objects.create(user=self.user)
+        self.customer = Customer.objects.create(user_id=1, address="111 test road", phone_number="5555555555")
+
+    def testDeleteOrder(self):
+        new_order = Order.objects.create(
+            customer_id = 1,
+            payment_type_id = None,
+            created_at = "2020-05-29T14:42:51.221420Z"
+        )
+
+        response = self.client.delete(
+            reverse('order-detail', kwargs={'pk': 1}), HTTP_AUTHORIZATION='Token ' + str(self.token))
+        
+        self.assertEqual(response.status_code, 204)
+
+        response = self.client.get(
+            reverse('order-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+
+        self.assertEqual(len(response.data), 0)
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ecommerceapi/views/order/orders.py
+++ b/ecommerceapi/views/order/orders.py
@@ -86,3 +86,18 @@ class Orders(ViewSet):
         ogOrder.save()
         return Response({}, status=status.HTTP_204_NO_CONTENT)
     
+    def destroy(self, request, pk=None):
+
+        try:
+            ogOrder = Order.objects.get(pk=pk)
+            ogOrder.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+        
+        # except Order.DoesNotExist as ex:
+        #     return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    


### PR DESCRIPTION
Fixes #9 

# Fetching Instructions
```shell
git fetch --all
git checkout kk-cancel-order
```

# Description
Please include a summary of the change and which issue is fixed.
A user can now click cancel order in the cart and the order itself (along with the product-order-relationships) will be deleted. 

# List of changes
- Added a button and a function to the MyCart.js in react side
- Added a delete endpoint in orders viewset 
- Added a testing folder called tests that holds all the tests. 
- to test open the api and run `python manage.py test`
- to view run the server
- open postman
-run the react app 
- create an order by adding products to it
- go to post man and go to localhost:8000/orders to see you most recent order
- note the ID***
- now in a new tab in postman go to localhost:8000/order_products?order_id={YOUR ID}
-in the react app when you click delete you should be redirected to the home page and your cart should be empty
- in postman you should refresh the order_products link and see an empty array (the products should still exist just not the relationship)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings