### PR TITLE
Kk product details 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ media/
 
 # django migrations
 migrations
+
+#db connection
+.connection

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ media/
 migrations
 
 #db connection
-.connection
+connection.py
+

--- a/ecommerceapi/models/model_factory.py
+++ b/ecommerceapi/models/model_factory.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+# Higher order function to create instances of models
+# when performing single table queries
+def model_factory(model_type):
+    def create(cursor, row):
+        instance = model_type()
+        smart_row = sqlite3.Row(cursor, row)
+        for col in smart_row.keys():
+            setattr(instance, col, smart_row[col])
+        return instance
+    return create

--- a/ecommerceapi/models/order_product.py
+++ b/ecommerceapi/models/order_product.py
@@ -10,6 +10,7 @@ class OrderProduct(models.Model):
     Arguments Required:
         order= ForeignKey for Order
         product= ForeignKey for Product
+        
           
   '''
   

--- a/ecommerceapi/models/product.py
+++ b/ecommerceapi/models/product.py
@@ -34,6 +34,7 @@ class Product(SafeDeleteModel):
     image_path = models.CharField(max_length=255)
     created_at = models.DateTimeField() 
     product_type = models.ForeignKey(ProductType, on_delete=models.DO_NOTHING)
+    amount_sold = 0
 
     def __str__(self):
         return f'{self.title}'

--- a/ecommerceapi/tests/__init__.py
+++ b/ecommerceapi/tests/__init__.py
@@ -1,1 +1,2 @@
 from .testorders import TestOrders
+from .testproducts import TestProducts

--- a/ecommerceapi/tests/testproducts.py
+++ b/ecommerceapi/tests/testproducts.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+from django.urls import reverse
+from ecommerceapi.models import Order, Customer, OrderProduct, Product, ProductType, PaymentType
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from unittest import skip
+
+class TestProducts(TestCase):
+
+    def setUp(self):
+        self.username = "TestUser"
+        self.password = "testword1"
+        self.user =  User.objects.create_user(
+            username=self.username, password=self.password)
+        self.token = Token.objects.create(user=self.user)
+        self.customer = Customer.objects.create(user_id=1, address="111 test road", phone_number="5555555555")
+        
+
+    def testListProducts(self):
+        ''' Set up all foreign databases that are needed'''
+        toys = ProductType.objects.create(name="Toys")
+        furby = Product.objects.create(
+            title="Furby",
+            customer_id=1,
+            price=3.00,
+            description="Demon baby from hell",
+            quantity=4, 
+            location="Nashville",
+            image_path="https://upload.wikimedia.org/wikipedia/en/7/70/Furby_picture.jpg",
+            created_at="2020-06-03 00:00:00",
+            product_type_id = 1)
+        pt = PaymentType.objects.create(
+            merchant_name="Stupid Company", 
+            account_number="1234123412341234", 
+            expiration_date="2024-01-01", 
+            customer_id=1, 
+            created_at="2020-05-27 15:08:30.518598")
+        order = Order.objects.create(
+            customer_id = 1, 
+            payment_type_id=1, 
+            created_at="2020-05-29 16:29:18.874982")
+        order_product = OrderProduct.objects.create(order_id = 1, product_id = 1)
+        order_product_two = OrderProduct.objects.create(order_id = 1, product_id = 1)
+        
+        response = self.client.get(
+            reverse('products-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+        
+        #check that the status code is 200 and the response is good!
+        self.assertEqual(response.status_code, 200)
+
+        #check that there is only one object in the list
+        self.assertEqual(len(response.data), 1)
+        
+        #check that the amount sold is 2 NOT 0 (by default it is 0 but the list method converts it the number based on order-products)
+        self.assertEqual(response.data[0]["amount_sold"], 2)
+
+
+

--- a/ecommerceapi/tests/testproducts.py
+++ b/ecommerceapi/tests/testproducts.py
@@ -27,18 +27,18 @@ class TestProducts(TestCase):
             quantity=4, 
             location="Nashville",
             image_path="https://upload.wikimedia.org/wikipedia/en/7/70/Furby_picture.jpg",
-            created_at="2020-06-03 00:00:00",
+            created_at="2020-06-03 00:00:00Z",
             product_type_id = 1)
         pt = PaymentType.objects.create(
             merchant_name="Stupid Company", 
             account_number="1234123412341234", 
             expiration_date="2024-01-01", 
             customer_id=1, 
-            created_at="2020-05-27 15:08:30.518598")
+            created_at="2020-05-27 15:08:30.518598Z")
         order = Order.objects.create(
             customer_id = 1, 
             payment_type_id=1, 
-            created_at="2020-05-29 16:29:18.874982")
+            created_at="2020-05-29 16:29:18.874982Z")
         order_product = OrderProduct.objects.create(order_id = 1, product_id = 1)
         order_product_two = OrderProduct.objects.create(order_id = 1, product_id = 1)
         

--- a/ecommerceapi/views/connection.py
+++ b/ecommerceapi/views/connection.py
@@ -1,0 +1,1 @@
+connection = "/Users/kurt/workspace/bangazon/2_bangazon/bangazon-ecommerce-api-iris-station/db.sqlite3"

--- a/ecommerceapi/views/connection.py
+++ b/ecommerceapi/views/connection.py
@@ -1,1 +1,0 @@
-connection = "/Users/kurt/workspace/bangazon/2_bangazon/bangazon-ecommerce-api-iris-station/db.sqlite3"

--- a/ecommerceapi/views/order_product/order_products.py
+++ b/ecommerceapi/views/order_product/order_products.py
@@ -87,7 +87,7 @@ class OrderProducts(ViewSet):
             prodCount = self.request.query_params.get('count', None)
             if prodCount is not None:
 
-                op = OrderProduct.objects.raw('''SELECT 
+                count = OrderProduct.objects.raw('''SELECT 
                 op.id opId,
                 op.order_id,
                 op.product_id,
@@ -97,7 +97,7 @@ class OrderProducts(ViewSet):
                 left join ecommerceapi_order o on  op.order_id = o.id
                 where o.payment_type_id Not NULL and product_id = ?
                 order by product_id''',
-                (count,))
+                (prodCount,))
 
             else:
                 serializer = OrderProductSerializer(op, context={'request':request})

--- a/ecommerceapi/views/order_product/order_products.py
+++ b/ecommerceapi/views/order_product/order_products.py
@@ -53,7 +53,10 @@ class OrderProducts(ViewSet):
         order_id = self.request.query_params.get('order_id', None)
         if order_id is not None:
             order_products = order_products.filter(order_id = order_id)
-        serializer = OrderProductSerializer(order_products, many=True, context={'request': request})
+            serializer = OrderProductSerializer(order_products, many=True, context={'request': request})
+        
+        else:
+            serializer = OrderProductSerializer(order_products, many=True, context={'request': request})
 
         return Response(serializer.data)
     
@@ -79,31 +82,5 @@ class OrderProducts(ViewSet):
 
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-    def retrieve(self, request, pk=None):
-        try:
-            op = OrderProduct.objects.get(pk=pk)
-
-            prodCount = self.request.query_params.get('count', None)
-            if prodCount is not None:
-
-                count = OrderProduct.objects.raw('''SELECT 
-                op.id opId,
-                op.order_id,
-                op.product_id,
-                o.id,
-                o.created_at
-                from ecommerceapi_orderproduct op 
-                left join ecommerceapi_order o on  op.order_id = o.id
-                where o.payment_type_id Not NULL and product_id = ?
-                order by product_id''',
-                (prodCount,))
-
-            else:
-                serializer = OrderProductSerializer(op, context={'request':request})
-
-                return Response(serializer.data)
-        except Exception as ex:
-            return HttpResponseServerError(ex)
     
 

--- a/ecommerceapi/views/order_product/order_products.py
+++ b/ecommerceapi/views/order_product/order_products.py
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from ecommerceapi.models import Order, Customer, Product, OrderProduct
-import sqlite3
 
 
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
@@ -87,20 +86,18 @@ class OrderProducts(ViewSet):
 
             prodCount = self.request.query_params.get('count', None)
             if prodCount is not None:
-                with sqlite3.connect
 
                 op = OrderProduct.objects.raw('''SELECT 
-                    op.id opId,
-                    op.order_id,
-                    op.product_id,
-                    o.id,
-                    o.created_at,
-                    COUNT(product_id) productCount
-                    from ecommerceapi_orderproduct op 
-                    left join ecommerceapi_order o on  op.order_id = o.id
-                    where o.payment_type_id Not NULL and product_id = ?
-                    group by product_id''',
-                    (pk,))
+                op.id opId,
+                op.order_id,
+                op.product_id,
+                o.id,
+                o.created_at
+                from ecommerceapi_orderproduct op 
+                left join ecommerceapi_order o on  op.order_id = o.id
+                where o.payment_type_id Not NULL and product_id = ?
+                order by product_id''',
+                (count,))
 
             else:
                 serializer = OrderProductSerializer(op, context={'request':request})

--- a/ecommerceapi/views/order_product/order_products.py
+++ b/ecommerceapi/views/order_product/order_products.py
@@ -9,6 +9,8 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from ecommerceapi.models import Order, Customer, Product, OrderProduct
+import sqlite3
+
 
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
@@ -85,6 +87,8 @@ class OrderProducts(ViewSet):
 
             prodCount = self.request.query_params.get('count', None)
             if prodCount is not None:
+                with sqlite3.connect
+
                 op = OrderProduct.objects.raw('''SELECT 
                     op.id opId,
                     op.order_id,

--- a/ecommerceapi/views/product/products.py
+++ b/ecommerceapi/views/product/products.py
@@ -68,7 +68,11 @@ class Products(ViewSet):
         if user is not None:
             products = products.filter(customer_id=customer.id)
 
+        
+        #this loop will count how many products are in the order_product table specifically ones where the paymenttypeid is not null 
+        # meaning the user has paid for the product.
         for product in products:
+
 
             productsSold = OrderProduct.objects.raw('''SELECT 
             op.id opId,
@@ -84,10 +88,6 @@ class Products(ViewSet):
 
             count = len(list(productsSold))
             product.amount_sold = count
-
-            # serializer = OrderProductSerializer(order_products, many=False, context={'request': request})
-            # print(serializer.data)
-            # return Response(serializer.data)
 
         serializer = ProductSerializer(products, many=True, context={"request": request})
         return Response(serializer.data)

--- a/ecommerceapi/views/product/products.py
+++ b/ecommerceapi/views/product/products.py
@@ -7,7 +7,7 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from ecommerceapi.models import Product, Customer
+from ecommerceapi.models import Product, Customer, OrderProduct
 from datetime import datetime
 
 class ProductSerializer(serializers.HyperlinkedModelSerializer):
@@ -22,7 +22,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
             view_name='products',
             lookup_field='id'
         )
-        fields = ('id', 'title', 'price', 'description', 'quantity', "location", 'created_at', 'image_path', 'product_type_id')
+        fields = ('id', 'title', 'price', 'description', 'quantity', "location", 'created_at', 'image_path', 'product_type_id', 'amount_sold')
         depth = 1
 
 class Products(ViewSet):
@@ -67,6 +67,27 @@ class Products(ViewSet):
 
         if user is not None:
             products = products.filter(customer_id=customer.id)
+
+        for product in products:
+
+            productsSold = OrderProduct.objects.raw('''SELECT 
+            op.id opId,
+            op.order_id,
+            op.product_id,
+            o.id,
+            o.created_at
+            from ecommerceapi_orderproduct op 
+            left join ecommerceapi_order o on  op.order_id = o.id
+            where o.payment_type_id Not NULL and product_id = %s
+            order by product_id''',
+            [product.id])
+
+            count = len(list(productsSold))
+            product.amount_sold = count
+
+            # serializer = OrderProductSerializer(order_products, many=False, context={'request': request})
+            # print(serializer.data)
+            # return Response(serializer.data)
 
         serializer = ProductSerializer(products, many=True, context={"request": request})
         return Response(serializer.data)


### PR DESCRIPTION
Fixes #15 

# Fetching Instructions
```shell
git fetch --all
git checkout kk-products-details-2
```

# Description
Here I listed how many products have been sold and the quantity remaining in the 'My Products' tab. I also fixed the bug when a user buys two products it only removed one. Now, it will remove 2 or however many a user buys (haven't fixed the negative quantity issue yet)


# List of changes
- Added `amount_sold = 0` to product model (you shouldn't need to make migrations)
- added loop in products list that changes that number from 0 to x (however many products have been sold based off of order_products table with an order that has a payment_type_id)
- altered MyListCard.js to only have one kind of card getting placed to the dom as well as showing that specific products quantity and amount sold
- added testing to the end point for products list

# How to test
- open app as normal (npm start && pym runserver) 
- test that amount sold under (my products tab is showing the accurate amount) 
- 'sell' one product and test that it reflects that on the page
- checkout with 2 of the same products and see that the quantity reflects that
- lastly in the api terminal run the `python manage.py test` and be sure no errors pop up.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings